### PR TITLE
Add retain and qos to mqtt publish

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -27,6 +27,6 @@ events = s.getWinterCreditEvents()
 
 if 'next' in events:
     for e in events['next']:
-        ret= mqtt_client.publish("winterpeaks/next/start", "%s %s" % (events['next'][e]['date'], events['next'][e]['start']))
-        ret= mqtt_client.publish("winterpeaks/next/finish", "%s %s" % (events['next'][e]['date'], events['next'][e]['end']))
-        ret= mqtt_client.publish("winterpeaks/next/pre_start", events['next'][e]['pre_start'])
+        ret= mqtt_client.publish("winterpeaks/next/start", "%s %s" % (events['next'][e]['date'], events['next'][e]['start']), qos=1, retain=True)
+        ret= mqtt_client.publish("winterpeaks/next/finish", "%s %s" % (events['next'][e]['date'], events['next'][e]['end']), qos=1, retain=True)
+        ret= mqtt_client.publish("winterpeaks/next/pre_start", events['next'][e]['pre_start'], qos=1, retain=True)


### PR DESCRIPTION
After some testing with mqtt.py I had some runs that would not populate all the values (start with no end or vice-versa). Adding a qos of 1 seems to have solved it.

I also enabled retain so that if mqtt.py publishes while the client system (home-assistant, node-red, etc) is not connected to MQTT the information can still be fetched later on when the connection is re-established.